### PR TITLE
Redesigns syncing to customers to contacts in Salesforce

### DIFF
--- a/app/models/customer_export.rb
+++ b/app/models/customer_export.rb
@@ -1,9 +1,9 @@
 require 'square_connect'
 
 class CustomerExport
-
-  def salesforce_client
-    @sf_client ||= ScanDonation.config.salesforce_client
+  def initialize(salesforce_client: ScanDonation.config.salesforce_client, wet_run: ScanDonation.config.wet_run?)
+    @salesforce_client = salesforce_client
+    @wet_run = wet_run
   end
 
   def export_to_salesforce(pagination_cursor: nil)
@@ -14,10 +14,11 @@ class CustomerExport
 
     Array(results&.customers).each do |customer|
       begin
-        synchronize_square_customer(customer)
+        create_square_customer(customer)
       rescue => e
         Rails.logger.error(e)
         Rollbar.error(e)
+        raise if Rails.env.test?
       end
     end
 
@@ -28,24 +29,63 @@ class CustomerExport
     end
   end
 
-  def synchronize_square_customer(customer)
+  private
+
+  def create_square_customer(customer)
     square_customer = SquareCustomer.find_or_initialize_by(square_id: customer.id)
     if square_customer.new_record?
-      push_customer_to_salesforce(customer)
+      id = find_square_customer_in_salesforce(customer)
+      if id.nil? && @wet_run
+        id = create_square_customer_in_salesforce(customer)
+      elsif id.nil?
+        Rails.logger.info "Dry run: would create #{customer} in Salesforce"
+      end
 
-      square_customer.pushed_as_of = customer.updated_at
-      square_customer.save!
+      if !id.nil?
+        square_customer.salesforce_id = id
+        square_customer.save!
+      end
     end
   end
 
-  def push_customer_to_salesforce(customer)
-    salesforce_client.synchronize_contact(
-      Salesforce::Contact.new(
+  def find_square_customer_in_salesforce(customer)
+    # Match on first name, last name, and email
+    if customer.given_name.present? && customer.family_name.present? && customer.email_address.present?
+      id = @salesforce_client.find_contact(
         first_name: customer.given_name,
         last_name:  customer.family_name,
-        email:      customer.email_address,
-      ),
-      dry_run: true
+        email:      customer.email_address
+      )
+      return id if id.present?
+    end
+
+    # Fall back to first name and last name
+    if customer.given_name.present? && customer.family_name.present?
+      id = @salesforce_client.find_contact(
+        first_name: customer.given_name,
+        last_name:  customer.family_name,
+      )
+      return id if id.present?
+    end
+
+    # Fall back to email
+    if customer.email_address.present?
+      id = @salesforce_client.find_contact(
+        email: customer.email_address
+      )
+      return id if id.present?
+    end
+
+    nil
+  end
+
+  def create_square_customer_in_salesforce(customer)
+    @salesforce_client.create_contact(
+      Salesforce::Contact.new(
+        first_name: customer.given_name.presence || "Unknown",
+        last_name:  customer.family_name.presence || "Unknown",
+        email:      customer.email_address.presence
+      )
     )
   end
 end

--- a/app/models/customer_export.rb
+++ b/app/models/customer_export.rb
@@ -34,15 +34,15 @@ class CustomerExport
   def create_square_customer(customer)
     square_customer = SquareCustomer.find_or_initialize_by(square_id: customer.id)
     if square_customer.new_record?
-      id = find_square_customer_in_salesforce(customer)
-      if id.nil? && @wet_run
-        id = create_square_customer_in_salesforce(customer)
-      elsif id.nil?
+      salesforce_id = find_square_customer_in_salesforce(customer)
+      if salesforce_id.nil? && @wet_run
+        salesforce_id = create_square_customer_in_salesforce(customer)
+      elsif salesforce_id.nil?
         Rails.logger.info "Dry run: would create #{customer} in Salesforce"
       end
 
-      if !id.nil?
-        square_customer.salesforce_id = id
+      if !salesforce_id.nil?
+        square_customer.salesforce_id = salesforce_id
         square_customer.save!
       end
     end

--- a/app/models/square_customer.rb
+++ b/app/models/square_customer.rb
@@ -1,4 +1,4 @@
 class SquareCustomer < ApplicationRecord
   validates :square_id, presence: true
-  validates :pushed_as_of, presence: true
+  validates :salesforce_id, presence: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,12 @@ module ScanDonation
   end
 
   class Configuration
+    # We default to not writing any data to Salesforce. If we are ready to
+    # actually sync, WET_RUN should be set to a non-empty value.
+    def wet_run?
+      ENV["WET_RUN"].present?
+    end
+
     def salesforce_client
       @salesforce_client ||= ::Salesforce::Client.new(
         client_id:      ENV.fetch("SALESFORCE_CLIENT_ID"),

--- a/db/migrate/20170520180233_remove_pushed_as_of_from_square_customers.rb
+++ b/db/migrate/20170520180233_remove_pushed_as_of_from_square_customers.rb
@@ -1,0 +1,5 @@
+class RemovePushedAsOfFromSquareCustomers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :square_customers, :pushed_as_of, :string, null: false
+  end
+end

--- a/db/migrate/20170520180311_add_salesforce_id_to_square_customers.rb
+++ b/db/migrate/20170520180311_add_salesforce_id_to_square_customers.rb
@@ -1,0 +1,5 @@
+class AddSalesforceIdToSquareCustomers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :square_customers, :salesforce_id, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170520141937) do
+ActiveRecord::Schema.define(version: 20170520180311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "square_customers", force: :cascade do |t|
     t.string "square_id", null: false
-    t.datetime "pushed_as_of", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "salesforce_id", null: false
     t.index ["square_id"], name: "index_square_customers_on_square_id", unique: true
   end
 

--- a/test/models/customer_export_test.rb
+++ b/test/models/customer_export_test.rb
@@ -18,9 +18,10 @@ class CustomerExportTest < ActiveSupport::TestCase
   end
 
   test 'sends customer records to salesforce' do
-    @salesforce_client_mock.expect(:synchronize_contact, true, [Salesforce::Contact, Hash])
+    @salesforce_client_mock.expect(:create_contact, "abc123", [Salesforce::Contact])
+    @salesforce_client_mock.expect(:find_contact, nil, [Hash])
     ScanDonation.config.stub(:salesforce_client, @salesforce_client_mock) do
-      CustomerExport.new.export_to_salesforce
+      CustomerExport.new(wet_run: true).export_to_salesforce
     end
     @salesforce_client_mock.verify
   end


### PR DESCRIPTION
* Create contacts only once. No more on-going sync.
* Adds fallback logic for finding existing contacts
* Adds 'wet run' mode which must be explicitly enabled before we write to Salesforce